### PR TITLE
Adding MockedWallet

### DIFF
--- a/tests/utils/MockedWallet.ts
+++ b/tests/utils/MockedWallet.ts
@@ -1,0 +1,56 @@
+import { WalletService } from '@/services/WalletService';
+import * as constants from '@/store/constants';
+import { WalletAddress } from '@/store/peginTx/types';
+import { LedgerSignedTx, TrezorSignedTx, Tx } from '@/types';
+
+interface TestCase {
+  accountAddresses: WalletAddress[];
+  walletAddressPerCall: number;
+  walletMaxCall: number;
+  signedTx: TrezorSignedTx | LedgerSignedTx | Error;
+}
+
+export default class MockedWallet extends WalletService {
+  testCase:TestCase;
+
+  constructor(testCase: TestCase) {
+    super(constants.BTC_NETWORK_TESTNET);
+    this.testCase = testCase;
+  }
+
+  setAddresses(walletAddresses: WalletAddress[]): void {
+    this.testCase.accountAddresses = walletAddresses;
+  }
+
+  getAccountAddresses(batch: number, startFrom: number): Promise<WalletAddress[]> {
+    return new Promise<WalletAddress[]>((resolve, reject) => {
+      const walletAddresses: WalletAddress[] = [];
+      if (this.testCase.accountAddresses.length >= (startFrom + batch)) {
+        for (let index = startFrom; index < (startFrom + batch); index += 1) {
+          walletAddresses.push(this.testCase.accountAddresses[index]);
+        }
+        resolve(walletAddresses);
+      } else {
+        reject(new Error('Not enough WalletAddresses defined'));
+      }
+    });
+  }
+
+  getWalletAddressesPerCall(): number {
+    return this.testCase.walletAddressPerCall;
+  }
+
+  getWalletMaxCall(): number {
+    return this.testCase.walletMaxCall;
+  }
+
+  sign(tx: Tx): Promise<TrezorSignedTx | LedgerSignedTx> {
+    return new Promise<TrezorSignedTx | LedgerSignedTx>((resolve, reject) => {
+      if (this.testCase.signedTx instanceof Error) {
+        reject(this.testCase.signedTx);
+      } else {
+        resolve(this.testCase.signedTx);
+      }
+    });
+  }
+}


### PR DESCRIPTION
                I0ve created the MockedWallet class in order to extend
                WalletService and provide an implemented class to the
                tests.