### PR TITLE
fix subcribers inform

### DIFF
--- a/src/services/WalletService.ts
+++ b/src/services/WalletService.ts
@@ -148,7 +148,6 @@ export abstract class WalletService {
             segwit: new SatoshiBig(balanceAccumulated.segwit.plus(balances.segwit), 'satoshi'),
             nativeSegwit: new SatoshiBig(balanceAccumulated.nativeSegwit.plus(balances.nativeSegwit), 'satoshi'),
           };
-          this.informSubscribers(balanceAccumulated);
         } else {
           const listOfAddresses: string[] = [];
           addresses.forEach((element) => { listOfAddresses.push(element.address); });
@@ -158,6 +157,7 @@ export abstract class WalletService {
             return;
           }
         }
+        this.informSubscribers(balanceAccumulated);
       } else {
         throw new Error('Error getting balances');
       }


### PR DESCRIPTION
                I've updated the wallet service to inform subscribers
                when the balance of an address batch is zero and are all
                used.