### PR TITLE
Fixing loading issue on empty wallets

### DIFF
--- a/src/services/WalletService.ts
+++ b/src/services/WalletService.ts
@@ -127,7 +127,7 @@ export default abstract class WalletService {
     };
     this.loadingBalances = true;
     const maxAddressPerCall: number = this.getWalletAddressesPerCall();
-
+    let addresses: WalletAddress[] = [];
     try {
       for (
         let startFrom = 0;
@@ -135,7 +135,7 @@ export default abstract class WalletService {
         startFrom += maxAddressPerCall
       ) {
         // eslint-disable-next-line no-await-in-loop
-        let addresses = await this.getAccountAddresses(maxAddressPerCall, startFrom);
+        addresses = await this.getAccountAddresses(maxAddressPerCall, startFrom);
         if (addresses.length === 0) {
           throw new Error('Error getting list of addresses - List of addresses is empty');
         }
@@ -182,6 +182,7 @@ export default abstract class WalletService {
       throw new Error(`Balance Error: ${error.message}`);
     } finally {
       this.loadingBalances = false;
+      this.informSubscribers(balanceAccumulated, addresses);
     }
   }
 


### PR DESCRIPTION
                I've fixed the behavior informing the subscribers if the
                addresess are unused or with 0 balance. It allows to
                display the form.