### PR TITLE
Fix index assignement liquality

### DIFF
--- a/src/middleware/TxBuilder/LiqualityTxBuilder.ts
+++ b/src/middleware/TxBuilder/LiqualityTxBuilder.ts
@@ -33,8 +33,8 @@ export default class LiqualityTxBuilder extends TxBuilder {
             }
           });
           const inputs: Array<LiqualityInput> = normalizedTx.inputs
-            .map((input) => ({
-              index: input.prev_index,
+            .map((input, index) => ({
+              index,
               derivationPath: LiqualityTxBuilder.getDerivationPathFromAddress(input.address),
             }));
           resolve({


### PR DESCRIPTION
                I've updated Liquality tx builder using the input index
                of the created transaction to be signed instead of the
                utxo index