### PR TITLE
Adding test coverage reporter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           recreate: true
-          path: code-coverage-results.md   
+          path: code-coverage-results.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: 2wp-app build
 
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   checkout-and-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,23 @@ jobs:
       - name: Unit test
         run: |
           npm run test:unit
+
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/cobertura-coverage.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '30 80'
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md   

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test:unit": "vue-cli-service test:unit --setupTestFrameworkScriptFile=./tests/setup.js --collect-coverage",
+    "test:unit": "vue-cli-service test:unit --setupTestFrameworkScriptFile=./tests/setup.js --coverageReporters='cobertura' --collect-coverage",
     "lint": "vue-cli-service lint",
     "scanner": "npx sonar-scanner"
   },


### PR DESCRIPTION
Changed the `test:unit` script to generate the cobertura.xml file
Added **_irongut/CodeCoverageSummary@v1.3.0_** to read the cobertura.xml report and validate the thresholds, in this case 30%.
Added **_marocchino/sticky-pull-request-comment@v2_** to create a comment on PR to show the coverage report.