### PR TITLE
warning message added when liquality wallet is used

### DIFF
--- a/src/components/pegout/PegOutForm.vue
+++ b/src/components/pegout/PegOutForm.vue
@@ -44,7 +44,8 @@
                 </v-col>
                 <v-col v-else cols="4" class="pb-0 px-0">
                   <v-row class="derive-button ml-1 mx-0 d-flex justify-center">
-                    <v-btn :disabled="!isReadyToSign"
+                    <v-btn :disabled="!isReadyToSign ||
+                      injectedProvider == appConstants.RLOGIN_LIQUALITY_WALLET"
                       outlined rounded
                       width="100%" height="38"
                       @click="openAddressDialog" >
@@ -54,6 +55,14 @@
                     </v-btn>
                   </v-row>
                 </v-col>
+                <v-container v-if="injectedProvider === appConstants.RLOGIN_LIQUALITY_WALLET"
+                  style="font-size: 14px;">
+                  <div>
+                    As you are using Liquality, you need to follow
+                    <a :href=appConstants.RSK_PEGOUT_DOCUMENTATION_URL class="d-inline blackish a"
+                        target='_blank'> this documentation</a> to get the destination address.
+                  </div>
+                </v-container>
               </v-row>
             </v-col>
           </v-row>
@@ -129,6 +138,10 @@ export default class PegOutForm extends Vue {
 
   environmentContext = EnvironmentContextProviderService.getEnvironmentContext();
 
+  injectedProvider = '';
+
+  appConstants = constants;
+
   recipientAddress = '';
 
   showAddressDialog = false;
@@ -175,7 +188,10 @@ export default class PegOutForm extends Vue {
   }
 
   switchDeriveButton(): void {
-    console.log('======================================');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.injectedProvider = this.session.rLoginInstance?.providerController.injectedProvider.name;
+    //
     this.isReadyToSign = !this.isReadyToSign;
   }
 

--- a/src/store/constants.ts
+++ b/src/store/constants.ts
@@ -2,6 +2,9 @@ export const WALLET_LEDGER = 'WALLET_LEDGER';
 export const WALLET_TREZOR = 'WALLET_TREZOR';
 export const WALLET_LIQUALITY = 'WALLET_LIQUALITY';
 
+export const RLOGIN_LIQUALITY_WALLET = 'Liquality';
+export const RSK_PEGOUT_DOCUMENTATION_URL = 'https://developers.rsk.co/rsk/rbtc/conversion/networks/mainnet/#rbtc-to-btc-conversion';
+
 // devices
 export const IS_TREZOR_CONNECTED = 'IS_TREZOR_CONNECTED';
 

--- a/src/styles/_exchange-form.scss
+++ b/src/styles/_exchange-form.scss
@@ -26,6 +26,10 @@
     color: #737778;
   }
 
+  a {
+    font-size: 14px;
+  }
+
   .v-btn__content {
     color: inherit !important;
     span {


### PR DESCRIPTION
Added a warning when the selected wallet is Liquality.
The "Get Bitcoin destination address" button remains disabled and a warning message appears with a link attached to redirect the user to the rsk documentation page.