### PR TITLE
Change pegout summary styles

### DIFF
--- a/src/components/exchange/TxSummaryFixed.vue
+++ b/src/components/exchange/TxSummaryFixed.vue
@@ -66,7 +66,7 @@
                 <v-col>
                   <v-row>
                     <span class="status-subtitle">
-                      {{ type === txType.PEGOUT ? 'Sender address:' : 'Device account:' }}
+                      {{ type === txType.PEGOUT ? 'Sender address:' : 'Device account' }}
                     </span>
                   </v-row>
                   <v-row>
@@ -304,15 +304,21 @@
           <h2 id="summary-title-from">{{fromTitle}}</h2>
         </v-row>
         <!-- Sender -->
-        <v-container class="px-0 py-2">
+        <v-container
+          :class="{'px-0 py-2': type === txType.PEGOUT,  'pb-0 pl-0': type === txType.PEGIN}">
           <v-row class="mx-0">
             <h1 class="boldie">
               {{ type === txType.PEGOUT ? 'Sender address' : 'Device account:' }}
             </h1>
           </v-row>
           <div class="form-field pt-2 pl-0">
-            <v-container class="pa-0">
+            <v-container v-if="type === txType.PEGOUT" class="pa-0">
               <p class="light-grayish">
+                {{ senderValue }}
+              </p>
+            </v-container>
+            <v-container v-else class="mark" id="summary-sender-address">
+              <p v-bind:class="{'grayish': senderValue === VALUE_INCOMPLETE_MESSAGE}">
                 {{ senderValue }}
               </p>
             </v-container>
@@ -337,13 +343,23 @@
         </v-container>
 
         <!-- Amount -->
-        <v-container class="px-0 py-2">
+        <v-container
+          :class="{'px-0 py-2': type === txType.PEGOUT,  'pb-0 pl-0': type === txType.PEGIN}">
           <v-row class="mx-0">
-            <h1 class="boldie">Amount</h1>
+            <h1 class="boldie">
+              {{ type === txType.PEGOUT
+              ? 'Amount'
+              : currencyFromTicker + 's:' }}
+            </h1>
           </v-row>
-          <div class="form-field pt-2 pl-0">
-            <v-container class="pa-0">
+          <div class="form-field pt-2 pl-0" :class="{'pb-2' : type === txType.PEGIN}">
+            <v-container v-if="type === txType.PEGOUT" class="pa-0">
               <p class="light-grayish">
+                {{ amount }} {{ currencyFromTicker }}
+              </p>
+            </v-container>
+            <v-container v-else class="mark" id="summary-amount">
+              <p :class="{'grayish': amount === '0'}">
                 {{ amount }} {{ currencyFromTicker }}
               </p>
             </v-container>
@@ -396,12 +412,12 @@
             </v-container>
           </div>
         </v-container>
-        <v-divider />
+        <v-divider v-if="type === txType.PEGOUT" />
       </v-container>
 
       <v-container class="pa-0 pt-4">
 
-        <v-container class="pa-0">
+        <v-container :class="[type === txType.PEGOUT ? 'pa-0' : 'pb-0 pl-0']">
           <v-row class="mx-0 mb-2 justify-end">
             <h2>{{ toTitle }}</h2>
           </v-row>

--- a/src/components/exchange/TxSummaryFixed.vue
+++ b/src/components/exchange/TxSummaryFixed.vue
@@ -2,7 +2,7 @@
   <v-container v-if="type && orientation" class="pa-0 ma-0">
     <v-row class="mx-0 pb-4 d-flex justify-center">
       <h2 class="text-center tx-text">
-        Transaction summary:
+        Operation summary
       </h2>
     </v-row>
     <v-row v-if="orientation === orientationTypes.HORIZONTAL"
@@ -297,22 +297,22 @@
       </v-col>
     </v-row>
     <v-row v-if="orientation === orientationTypes.VERTICAL"
-           class="mx-0 px-5 pb-5 summary-box">
+           class="mx-0 pa-6 summary-box">
       <!-- title -->
-      <v-container class="pb-0 pl-0">
-        <v-row class="mx-0">
+      <v-container class="pa-0">
+        <v-row class="mx-0 mb-2">
           <h2 id="summary-title-from">{{fromTitle}}</h2>
         </v-row>
         <!-- Sender -->
-        <v-container class="pb-0 pl-0" >
+        <v-container class="px-0 py-2">
           <v-row class="mx-0">
             <h1 class="boldie">
-              {{ type === txType.PEGOUT ? 'Sender address:' : 'Device account:' }}
+              {{ type === txType.PEGOUT ? 'Sender address' : 'Device account:' }}
             </h1>
           </v-row>
           <div class="form-field pt-2 pl-0">
-            <v-container class="mark" id="summary-sender-address">
-              <p v-bind:class="{'grayish': senderValue === VALUE_INCOMPLETE_MESSAGE}">
+            <v-container class="pa-0">
+              <p class="light-grayish">
                 {{ senderValue }}
               </p>
             </v-container>
@@ -337,13 +337,13 @@
         </v-container>
 
         <!-- Amount -->
-        <v-container class="pb-0 pl-0" >
+        <v-container class="px-0 py-2">
           <v-row class="mx-0">
-            <h1 class="boldie">{{ currencyFromTicker }}s:</h1>
+            <h1 class="boldie">Amount</h1>
           </v-row>
-          <div class="form-field pt-2 pb-2 pl-0">
-            <v-container class="mark" id="summary-amount">
-              <p v-bind:class="{'grayish': amount === '0'}">
+          <div class="form-field pt-2 pl-0">
+            <v-container class="pa-0">
+              <p class="light-grayish">
                 {{ amount }} {{ currencyFromTicker }}
               </p>
             </v-container>
@@ -384,40 +384,39 @@
         </v-container>
 
         <!-- Gas -->
-        <v-container v-if="type === txType.PEGOUT" class="pb-0 pl-0" >
+        <v-container v-if="type === txType.PEGOUT" class="px-0 pt-2 pb-4">
           <v-row class="mx-0">
-            <h1 class="boldie">Transaction fee:</h1>
+            <h1 class="boldie">Gas</h1>
           </v-row>
-          <div class="form-field pt-2 pb-2 pl-0">
-            <v-container class="mark" id="summary-tx-fee">
-              <p v-bind:class="{'grayish': summary.gas === 0}">
+          <div class="form-field pt-2 pl-0">
+            <v-container class="pa-0">
+              <p class="light-grayish">
                 {{ summary.gas }} {{currencyFromTicker}}
               </p>
             </v-container>
           </div>
         </v-container>
+        <v-divider />
       </v-container>
 
-      <v-divider/>
-      <v-container class="pb-0 pl-0">
+      <v-container class="pa-0 pt-4">
 
-        <v-container class="pb-0 pl-0">
-          <v-row class="mx-0 justify-end">
+        <v-container class="pa-0">
+          <v-row class="mx-0 mb-2 justify-end">
             <h2>{{ toTitle }}</h2>
           </v-row>
         </v-container>
 
         <!-- Recipient -->
-        <v-container v-if="type === txType.PEGOUT" class="pb-0 pl-0" >
+        <v-container v-if="type === txType.PEGOUT" class="px-0 py-2">
           <v-row class="justify-end mx-0">
             <h1 class="boldie">
-              Bitcoin destination address:
+              Recipient address
             </h1>
           </v-row>
           <div class="form-field pt-2 pl-0">
-            <v-container class="mark" id="summary-btc-destination">
-              <p v-bind:class="{'grayish': recipientAddress === VALUE_INCOMPLETE_MESSAGE}"
-                 class="text-end">
+            <v-container class="pa-0">
+              <p class="light-grayish text-end">
                 {{ recipientAddress }}
               </p>
             </v-container>
@@ -440,16 +439,15 @@
         </v-container>
 
         <!-- Fee PEGOUT -->
-        <v-container v-if="type === txType.PEGOUT" class="pb-0 pl-0">
+        <v-container v-if="type === txType.PEGOUT" class="px-0 py-2">
           <v-row class="justify-end mx-0">
             <h1 class="boldie">
-             Estimated fee to pay:
+             Estimated fee to pay
             </h1>
           </v-row>
           <div class="form-field pt-2 pl-0">
-            <v-container class="mark" id="summary-estimated-fee">
-              <p v-bind:class="{'grayish': summary.fee === 0}"
-                 class="text-end">
+            <v-container class="pa-0">
+              <p class="light-grayish text-end">
                 {{ summary.fee }}
                 {{ currencyToTicker }}
               </p>
@@ -458,16 +456,15 @@
         </v-container>
 
         <!-- Estimated BTC to receive -->
-        <v-container v-if="type === txType.PEGOUT" class="pb-0 pl-0">
+        <v-container v-if="type === txType.PEGOUT" class="pa-0 pt-2">
           <v-row class="justify-end mx-0">
             <h1 class="boldie">
-              Estimated {{environmentContext.getBtcTicker()}} to receive:
+              Estimated {{environmentContext.getBtcTicker()}} to receive
             </h1>
           </v-row>
           <div class="form-field pt-2 pl-0">
-            <v-container class="mark" id="summary-btc-estimated-amount">
-              <p v-bind:class="{'grayish': summary.amountReceivedString === '0'}"
-                 class="text-end">
+            <v-container class="pa-0">
+              <p class="light-grayish text-end">
                 {{ summary.amountReceivedString }} {{currencyToTicker}}
               </p>
             </v-container>

--- a/src/styles/_site.scss
+++ b/src/styles/_site.scss
@@ -143,8 +143,8 @@ a {
   font-weight: bold;
 }
 
-.ligth-grayish {
-  color: #F5FAFF !important;
+.light-grayish {
+  color: #747272 !important;
 }
 
 .max-width {

--- a/tests/unit/components/txSummary.spec.ts
+++ b/tests/unit/components/txSummary.spec.ts
@@ -6,7 +6,7 @@ import * as constants from '@/store/constants';
 import { EnvironmentAccessorService } from '@/services/enviroment-accessor.service';
 import sinon from 'sinon';
 import {
-  NormalizedSummary, PegoutStatus, SatoshiBig, TxStatusType, TxSummaryOrientation, WeiBig,
+  NormalizedSummary, SatoshiBig, TxStatusType, TxSummaryOrientation, WeiBig,
 } from '@/types';
 
 const localVue = createLocalVue();


### PR DESCRIPTION
On pegout transaction screen:
- Changed 'Transaction summary' to 'Operation summary' 
- Fixed spacing
- Removed all ':'
- Added divider
- Removed fields background
- Changed subtitles according to proposed design

<img width="387" alt="Screenshot 2023-04-27 at 20 33 44" src="https://user-images.githubusercontent.com/117093501/234971238-28890054-9000-4ee6-911c-4ab46879dbc5.png">
