### PR TITLE
Improve recipient tooltip

### DIFF
--- a/src/components/exchange/TxSummaryFixed.vue
+++ b/src/components/exchange/TxSummaryFixed.vue
@@ -143,7 +143,8 @@
                     <v-tooltip right>
                       <template v-slot:activator="{ on, attrs }">
                         <v-icon small color="#000000"
-                                v-bind="attrs" v-on="on">
+                                v-bind="attrs" v-on="on"
+                                class="tooltip-info-icon">
                           mdi-information
                         </v-icon>
                       </template>
@@ -190,14 +191,26 @@
                     <v-tooltip right>
                       <template v-slot:activator="{ on, attrs }">
                         <v-icon small color="#000000"
-                                v-bind="attrs" v-on="on">
-                          mdi-information
+                            v-if="recipientAddress === '-'"
+                            @click="openDerivationAddressDocumentation"
+                            v-bind="attrs" v-on="on"
+                            class="tooltip-clickable-icon">
+                            mdi-information
+                        </v-icon>
+                        <v-icon v-else
+                            small color="#000000"
+                            v-bind="attrs" v-on="on"
+                            class="tooltip-info-icon">
+                            mdi-information
                         </v-icon>
                       </template>
                       <p class="tooltip-form mb-0">
-                        This is the {{networkToText}}
+                        This is the {{networkToText}} destination
                         address where the
                         {{networkToText}} will be delivered.
+                      </p>
+                      <p v-if="recipientAddress === '-'" class="tooltip-form mb-0">
+                        Click here to know how to get it.
                       </p>
                     </v-tooltip>
                   </v-row>
@@ -522,6 +535,8 @@ export default class TxSummaryFixed extends Vue {
 
   txType = TxStatusType;
 
+  appConstants = constants;
+
   @State('web3Session') sessionState!: SessionState;
 
   @Emit()
@@ -678,6 +693,11 @@ export default class TxSummaryFixed extends Vue {
     } else {
       window.open(getBtcAddressExplorerUrl(this.summary.recipientAddress || ''), '_blank');
     }
+  }
+
+  @Emit()
+  openDerivationAddressDocumentation() {
+    window.open(`${this.appConstants.RSK_PEGOUT_DOCUMENTATION_URL}`);
   }
 }
 </script>

--- a/src/styles/_exchange-form.scss
+++ b/src/styles/_exchange-form.scss
@@ -252,6 +252,14 @@
   font-size: 14px;
 }
 
+.tooltip-info-icon {
+  cursor: default;
+}
+
+.tooltip-clickable-icon {
+  cursor: pointer;
+}
+
 .account-select {
   .v-select__selection {
     font-size: 13px;


### PR DESCRIPTION
A link to RSK documentation for address derivation was added in recipient tooltip.
The cursor has also been modified to be a hand pointer only when it performs an action. 

https://github.com/rsksmart/2wp-app/assets/83707069/1fe52fba-44ef-4133-a8dd-0b30b7d6f733


Otherwise, the default one remains.

https://github.com/rsksmart/2wp-app/assets/83707069/00e25ba6-7425-468a-9176-8d5a3f151a3d

(This was also added to the tx-hash's mdi-information icon)
It all looks fine on final pegout stage page and on tx-status page.
