### PR TITLE
Migrate unused addresses logic

### DIFF
--- a/src/pegin/services/UnusedAddressesService.ts
+++ b/src/pegin/services/UnusedAddressesService.ts
@@ -1,0 +1,27 @@
+import { EnvironmentAccessorService } from '@/common/services/enviroment-accessor.service';
+import { AddressStatus, SatoshiBig } from '@/common/types';
+import axios from 'axios';
+import { AddressInfo } from '../types';
+
+export class UnusedAddressesService {
+  private static getAddressInfo(address: string): Promise<AddressInfo> {
+    const baseUrl = EnvironmentAccessorService.getEnvironmentVariables().vueAppApiBaseUrl;
+
+    return axios.get(`${baseUrl}/api/v2/address/${address}`)
+      .then((response) => response.data);
+  }
+
+  public static areUnusedAddresses(addressList: string[]): Promise<AddressStatus[]> {
+    const addressInfoPromises = addressList.map((address) => this.getAddressInfo(address));
+
+    return Promise.all(addressInfoPromises)
+      .then((addressesInfo) => addressesInfo.map(
+        (addressInfo) => {
+          const totalReceived = new SatoshiBig(addressInfo.totalReceived, 'satoshi');
+          const totalSent = new SatoshiBig(addressInfo.totalSent, 'satoshi');
+          const unused = totalReceived.eq(0) && totalSent.eq(0);
+          return { address: addressInfo.address, unused };
+        },
+      )).catch((e) => { throw e; });
+  }
+}

--- a/src/pegin/types/index.ts
+++ b/src/pegin/types/index.ts
@@ -1,0 +1,5 @@
+export interface AddressInfo {
+  address: string;
+  totalReceived: string;
+  totalSent: string;
+}

--- a/tests/unit/pegin/services/UnusedAddressesService.spec.ts
+++ b/tests/unit/pegin/services/UnusedAddressesService.spec.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { UnusedAddressesService } from '@/pegin/services/UnusedAddressesService';
+import { AddressInfo } from '@/pegin/types';
+import { EnvironmentAccessorService } from '@/common/services/enviroment-accessor.service';
+import * as constants from '@/common/store/constants';
+import sinon from 'sinon';
+
+const API_URL = 'https://api.url';
+
+function setEnvironment() {
+  const defaultEnvironmentVariables = {
+    vueAppCoin: constants.BTC_NETWORK_TESTNET,
+    vueAppRskNodeHost: '',
+    vueAppApiBaseUrl: API_URL,
+  };
+  EnvironmentAccessorService.initializeEnvironmentVariables(defaultEnvironmentVariables);
+}
+
+describe('UnusedAddresses Service', () => {
+  beforeEach(setEnvironment);
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return given an address list which addresses are unused', () => {
+    const addressesInfo: AddressInfo[] = [
+      { address: 'A', totalReceived: '0', totalSent: '0' },
+      { address: 'B', totalReceived: '1', totalSent: '0' },
+    ];
+
+    const axiosStub = sinon.stub(axios);
+    axiosStub.get
+      .withArgs(`${API_URL}/api/v2/address/A`)
+      .resolves({ data: addressesInfo[0] })
+      .withArgs(`${API_URL}/api/v2/address/B`)
+      .resolves({ data: addressesInfo[1] });
+
+    const addressesWithStatus = [
+      { address: 'A', unused: true },
+      { address: 'B', unused: false },
+    ];
+
+    expect(UnusedAddressesService.areUnusedAddresses(['A', 'B']))
+      .resolves
+      .toEqual(addressesWithStatus);
+  });
+});


### PR DESCRIPTION
Created unused addresses service to migrate that peg-in functionality from backend