### PR TITLE
Add Tx fee calculation

### DIFF
--- a/src/pegin/services/index.ts
+++ b/src/pegin/services/index.ts
@@ -1,3 +1,4 @@
 export { default as TxFeeService } from './TxFeeService';
 export { default as PeginTxService } from './PeginTxService';
 export { default as UnusedAddressesService } from './UnusedAddressesService';
+export { default } from './TxFeeService';


### PR DESCRIPTION
		We've created the TxFeeService in order to properly calculate the btc tx fee
		based on the current utxo list provided. It adds some environment variables specifying
		the min speed fee and the mining speed block.