### PR TITLE
Handle missing BTC price

### DIFF
--- a/src/common/store/constants.ts
+++ b/src/common/store/constants.ts
@@ -223,6 +223,7 @@ export const SUPPORTED_NETWORKS = {
 };
 
 export const GETTING_FUNDS_DOCUMENTATION_URL = 'https://developers.rsk.co/guides/two-way-peg-app/getting-started/#getting-funds';
+export const COINGECKO_API_URL = 'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin&order=market_cap_desc&per_page=100&page=1&sparkline=false';
 // Peg-out status
 export const PEGOUT_SIGNING_BLOCKS_GAP = 30;
 export const PEGOUT_REQUIRED_CONFIRMATIONS = 4000;

--- a/src/common/store/session/actions.ts
+++ b/src/common/store/session/actions.ts
@@ -106,10 +106,15 @@ export const actions: ActionTree<SessionState, RootState> = {
         commit(constants.SESSION_SET_BTC_ACCOUNT, btcAddress);
       }
     },
-  [constants.SESSION_ADD_BITCOIN_PRICE]: ({ commit }) => axios.get('https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin&order=market_cap_desc&per_page=100&page=1&sparkline=false')
+  [constants.SESSION_ADD_BITCOIN_PRICE]: ({ commit }) => axios.get(constants.COINGECKO_API_URL)
     .then((response: AxiosResponse) => {
       const [result] = response.data;
       commit(constants.SESSION_SET_BITCOIN_PRICE, result.current_price);
+    })
+    .catch(() => {
+      commit(constants.SESSION_SET_BITCOIN_PRICE, 0);
+    })
+    .finally(() => {
       commit(constants.SESSION_SET_TX_TYPE, 'PEG_IN_TRANSACTION_TYPE');
     }),
   [constants.SESSION_CLEAR]: ({ commit }) => {

--- a/src/common/views/Home.vue
+++ b/src/common/views/Home.vue
@@ -137,8 +137,6 @@ export default {
     const clear = useAction('pegInTx', constants.PEGIN_TX_CLEAR_STATE);
     const clearPegOut = useAction('pegOutTx', constants.PEGOUT_TX_CLEAR);
     const clearSession = useAction('web3Session', constants.SESSION_CLEAR);
-    const initPegin = useAction('pegInTx', constants.PEGIN_TX_INIT);
-    const init = useAction('pegOutTx', constants.PEGOUT_TX_INIT);
     const addPeg = useAction('web3Session', constants.SESSION_ADD_TX_TYPE);
 
     const btcToRbtc = computed((): boolean => txType.value === constants.PEG_IN_TRANSACTION_TYPE);
@@ -182,8 +180,6 @@ export default {
     clearPegOut();
     clearSession();
     addPeg();
-    init();
-    initPegin();
 
     return {
       environmentContext,

--- a/src/pegin/store/actions.ts
+++ b/src/pegin/store/actions.ts
@@ -56,10 +56,13 @@ export const actions: ActionTree<PegInTxState, RootState> = {
       },
     );
   },
-  [constants.PEGIN_TX_ADD_BITCOIN_PRICE]: ({ commit }) => axios.get('https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin&order=market_cap_desc&per_page=100&page=1&sparkline=false')
+  [constants.PEGIN_TX_ADD_BITCOIN_PRICE]: ({ commit }) => axios.get(constants.COINGECKO_API_URL)
     .then((response: AxiosResponse) => {
       const [result] = response.data;
       commit(constants.PEGIN_TX_SET_BITCOIN_PRICE, result.current_price);
+    })
+    .catch(() => {
+      commit(constants.PEGIN_TX_SET_BITCOIN_PRICE, 0);
     }),
   [constants.PEGIN_TX_CLEAR_STATE]: ({ commit }): void => {
     commit(constants.PEGIN_TX_CLEAR);

--- a/src/pegin/views/PegIn.vue
+++ b/src/pegin/views/PegIn.vue
@@ -12,6 +12,8 @@
 import { onBeforeMount, ref, defineComponent } from 'vue';
 import SelectBitcoinWallet from '@/common/components/exchange/SelectBitcoinWallet.vue';
 import BtcToRbtcDialog from '@/common/components/exchange/BtcToRbtcDialog.vue';
+import { useAction } from '@/common/store/helper';
+import * as constants from '@/common/store/constants';
 
 export default defineComponent({
   name: 'PegIn',
@@ -22,6 +24,8 @@ export default defineComponent({
   setup() {
     const showDialog = ref(false);
 
+    const initPegin = useAction('pegInTx', constants.PEGIN_TX_INIT);
+
     function closeDialog() {
       showDialog.value = false;
     }
@@ -29,6 +33,8 @@ export default defineComponent({
     onBeforeMount(() => {
       showDialog.value = localStorage.getItem('BTRD_COOKIE_DISABLED') !== 'true';
     });
+
+    initPegin();
 
     return {
       showDialog,

--- a/src/pegout/store/pegoutTx/actions.ts
+++ b/src/pegout/store/pegoutTx/actions.ts
@@ -82,9 +82,12 @@ export const actions: ActionTree<PegOutTxState, RootState> = {
   [constants.PEGOUT_TX_CLEAR]: ({ commit }) => {
     commit(constants.PEGOUT_TX_CLEAR_STATE);
   },
-  [constants.PEGOUT_TX_ADD_BITCOIN_PRICE]: ({ commit }) => axios.get('https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin&order=market_cap_desc&per_page=100&page=1&sparkline=false')
+  [constants.PEGOUT_TX_ADD_BITCOIN_PRICE]: ({ commit }) => axios.get(constants.COINGECKO_API_URL)
     .then((response: AxiosResponse) => {
       const [result] = response.data;
       commit(constants.PEGOUT_TX_SET_BITCOIN_PRICE, result.current_price);
+    })
+    .catch(() => {
+      commit(constants.PEGOUT_TX_SET_BITCOIN_PRICE, 0);
     }),
 };


### PR DESCRIPTION
Add a 0 default value if Coingecko promise is rejected and no Bitcoin price is set.