### PR TITLE
Add fiat amounts to pegin summary

### DIFF
--- a/src/common/components/exchange/TxSummaryFixed.vue
+++ b/src/common/components/exchange/TxSummaryFixed.vue
@@ -370,7 +370,7 @@
                 {{ summary.fee }}
                 {{ currencyFromTicker }}
               </p>
-              <span>{{ feeUSD }}</span>
+              <span>USD {{ feeUSD }}</span>
             </v-container>
           </div>
         </v-container>
@@ -387,7 +387,7 @@
               <p class="light-grayish">
                 {{ total }} {{currencyFromTicker}}
               </p>
-              <span>{{ totalUSD }}</span>
+              <span>USD {{ totalUSD }}</span>
             </v-container>
           </div>
         </v-container>
@@ -613,14 +613,14 @@ export default defineComponent({
     const feeUSD = computed((): string => {
       const feeAmount = new SatoshiBig(props.summary?.fee || 0, 'btc');
       if (!feeAmount || !bitcoinPrice.value) return VALUE_INCOMPLETE_MESSAGE;
-      return `$${feeAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
+      return `${feeAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
     });
 
     const totalUSD = computed((): string => {
       const totalValue = total.value === VALUE_INCOMPLETE_MESSAGE ? 0 : total.value;
       const totalAmount = new SatoshiBig(totalValue, 'btc');
       if (!totalAmount || !bitcoinPrice.value) return VALUE_INCOMPLETE_MESSAGE;
-      return `$${totalAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
+      return `${totalAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
     });
 
     const federationAddress = computed((): string => (

--- a/src/common/components/exchange/TxSummaryFixed.vue
+++ b/src/common/components/exchange/TxSummaryFixed.vue
@@ -352,6 +352,7 @@
               <p class="light-grayish">
                 {{ amount }} {{ currencyFromTicker }}
               </p>
+              <span v-if="type === txType.PEGIN">{{ amountUSD }}</span>
             </v-container>
           </div>
         </v-container>
@@ -369,6 +370,7 @@
                 {{ summary.fee }}
                 {{ currencyFromTicker }}
               </p>
+              <span>{{ feeUSD }}</span>
             </v-container>
           </div>
         </v-container>
@@ -385,6 +387,7 @@
               <p class="light-grayish">
                 {{ total }} {{currencyFromTicker}}
               </p>
+              <span>{{ totalUSD }}</span>
             </v-container>
           </div>
         </v-container>
@@ -472,10 +475,11 @@
             </h1>
           </v-row>
           <div class="form-field pt-2 pl-0">
-            <v-container class="pa-0" id="summary-btc-estimated-amount">
-              <p class="light-grayish text-end">
+            <v-container class="pa-0 text-end" id="summary-btc-estimated-amount">
+              <p class="light-grayish">
                 {{ amount }}  {{currencyToTicker}}
               </p>
+              <span>{{ amountUSD }}</span>
             </v-container>
           </div>
         </v-container>
@@ -602,16 +606,21 @@ export default defineComponent({
 
     const amountUSD = computed((): string => {
       const btcAmount = new SatoshiBig(props.summary?.amountFromString || 0, 'btc');
-      if (!btcAmount || !bitcoinPrice) return VALUE_INCOMPLETE_MESSAGE;
-      // TODO: check casting accuracy
-      return btcAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals);
+      if (!btcAmount || !bitcoinPrice.value) return VALUE_INCOMPLETE_MESSAGE;
+      return `$${btcAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
+    });
+
+    const feeUSD = computed((): string => {
+      const feeAmount = new SatoshiBig(props.summary?.fee || 0, 'btc');
+      if (!feeAmount || !bitcoinPrice.value) return VALUE_INCOMPLETE_MESSAGE;
+      return `$${feeAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
     });
 
     const totalUSD = computed((): string => {
       const totalValue = total.value === VALUE_INCOMPLETE_MESSAGE ? 0 : total.value;
       const totalAmount = new SatoshiBig(totalValue, 'btc');
-      if (!totalAmount || !bitcoinPrice) return VALUE_INCOMPLETE_MESSAGE;
-      return totalAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals);
+      if (!totalAmount || !bitcoinPrice.value) return VALUE_INCOMPLETE_MESSAGE;
+      return `$${totalAmount.toUSDFromBTCString(bitcoinPrice.value, fixedUSDDecimals)}`;
     });
 
     const federationAddress = computed((): string => (
@@ -704,6 +713,7 @@ export default defineComponent({
       amountToReceive,
       total,
       amountUSD,
+      feeUSD,
       totalUSD,
       federationAddress,
       networkFromText,

--- a/src/pegin/components/create/BtcFeeSelect.vue
+++ b/src/pegin/components/create/BtcFeeSelect.vue
@@ -9,9 +9,9 @@
         <p v-bind:class="{'boldie' : focus}">
           Select transaction fee:
         </p>
-        <v-row class="mx-0 mt-4 d-flex justify-start">
+        <v-row class="ma-0 d-flex justify-start">
           <v-col cols="11 pl-0">
-            <v-row class="mx-0">
+            <v-row class="ma-0">
               <v-slider v-model="txFeeIndex" :ticks="transactionFees" max="2"
                         track-size="2"
                         thumb-size="12"
@@ -19,9 +19,9 @@
                         :color="txFeeColor" :track-color="txFeeColor" step="1"
                         @update:focused="focus = !focus"
                         @blur="focus = false"
-                        @change="updateStore"/>
+                        />
             </v-row>
-            <v-row class="mx-0">
+            <v-row class="ma-0">
               <v-col cols="4" class="d-flex justify-start pa-0">
                       <span class="text-left">{{ slowFee }}
                       {{environmentContext.getBtcTicker()}}</span>
@@ -35,7 +35,7 @@
                       {{environmentContext.getBtcTicker()}}</span>
               </v-col>
             </v-row>
-            <v-row class="mx-0">
+            <v-row class="ma-0">
               <v-col cols="4" class="d-flex justify-start pa-0">
                 <span class="boldie text-left">$ {{ slowFeeUSD }}</span>
               </v-col>
@@ -48,7 +48,7 @@
             </v-row>
           </v-col>
         </v-row>
-        <v-row v-if="showErrorMessage" class="mx-0 mt-0 d-flex justify-start">
+        <v-row v-if="showErrorMessage" class="ma-0 d-flex justify-start">
           <span class="message-error-fee">
             You don't have the balance for this fee + amount
           </span>
@@ -60,7 +60,7 @@
 
 <script lang="ts">
 import {
-  computed, onBeforeMount, ref, defineComponent,
+  computed, onBeforeMount, ref, defineComponent, watch,
 } from 'vue';
 import * as constants from '@/common/store/constants';
 import { MiningSpeedFee } from '@/common/types/pegInTx';
@@ -131,6 +131,8 @@ export default defineComponent({
       }
       setSelectedFee(userSelectedFee);
     }
+
+    watch(() => txFeeIndex.value, updateStore);
 
     onBeforeMount(() => {
       let selectedFeeIdx = 1;


### PR DESCRIPTION
Fix pegin fee selection slider.
Add fiat value in USD for pegin summary fields: amount, fee and total.

<img width="371" alt="image" src="https://github.com/rsksmart/2wp-app/assets/117093501/059ce644-a228-444c-a4e0-73bf8f4698a4">
