### PR TITLE
fixing to reuse the available function

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -63,7 +63,7 @@ export function getEstimatedFee(): Promise<SatoshiBig> {
       bridgeService.getQueuedPegoutsCount(),
     ])
       .then(([nextPegoutCost, pegoutQueueCount]) => {
-        const estimatedFee = nextPegoutCost / (pegoutQueueCount + 1);
+        const estimatedFee = pegoutQueueCount > 0 ? nextPegoutCost / pegoutQueueCount : 0;
         resolve(new SatoshiBig(estimatedFee, 'satoshi'));
       })
       .catch(reject);

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -63,7 +63,7 @@ export function getEstimatedFee(): Promise<SatoshiBig> {
       bridgeService.getQueuedPegoutsCount(),
     ])
       .then(([nextPegoutCost, pegoutQueueCount]) => {
-        const estimatedFee = pegoutQueueCount > 0 ? nextPegoutCost / pegoutQueueCount : 0;
+        const estimatedFee = nextPegoutCost / (pegoutQueueCount + 1);
         resolve(new SatoshiBig(estimatedFee, 'satoshi'));
       })
       .catch(reject);

--- a/src/pegout/store/pegoutTx/actions.ts
+++ b/src/pegout/store/pegoutTx/actions.ts
@@ -6,7 +6,6 @@ import {
   MiningSpeedFee, PegOutTxState, RootState, SatoshiBig, SessionState, WeiBig,
 } from '@/common/types';
 import { EnvironmentAccessorService } from '@/common/services/enviroment-accessor.service';
-import { BridgeService } from '@/common/services/BridgeService';
 import { getEstimatedFee } from '@/common/utils';
 
 export const actions: ActionTree<PegOutTxState, RootState> = {


### PR DESCRIPTION
This PR solves the security comment above:

Vadym Kolisnichenko commented:

Hey [Alex Simas Braz](https://rsklabs.atlassian.net/secure/ViewProfile.jspa?accountId=623cd85a9b54ec0068b1bee2) ,

qq: do you know what was the reason to replace const estimatedFee = await getEstimatedFee(); with this calculation onst estimatedFee = pegoutQueueCount > 0 ? nextPegoutCost / pegoutQueueCount : 0; in actions.ts https://github.com/rsksmart/2wp-app/commit/22528d05d59649210ac835e4cdaa9bbab315538b#diff-677ba70779b5e66e7a47e4c6e9409baf147aa156a4bb85ad860a7dd152b26003L33 