### PR TITLE
Add btc price cookie

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,7 +33,6 @@ export default {
   setup() {
     let scriptTag: HTMLScriptElement;
     let hotjarScriptTag: HTMLScriptElement;
-    const getBtcPrice = useAction('web3Session', constants.SESSION_ADD_BITCOIN_PRICE);
     const enableTermsAndConditions = useAction('web3Session', constants.SESSION_ADD_TERMS_AND_CONDITIONS_ENABLED);
     const showTermsAndConditions = ref(false);
     const contentSecurityPolicy = computed((): string => {
@@ -92,7 +91,6 @@ export default {
 
     enableTermsAndConditions();
     appendHotjar();
-    getBtcPrice();
     appendClarity();
     appendCSP();
     return {

--- a/src/common/store/constants.ts
+++ b/src/common/store/constants.ts
@@ -274,3 +274,4 @@ export const WALLET_NAMES = {
   METAMASK: 'metamask',
 } as const;
 export const PEGIN_OUTPUTS = 3;
+export const COOKIE_EXPIRATION_HOURS = 12;

--- a/src/common/store/session/mutations.ts
+++ b/src/common/store/session/mutations.ts
@@ -33,7 +33,7 @@ export const mutations: MutationTree<SessionState> = {
   [constants.SESSION_SET_BTC_ACCOUNT]: (state, btcDerivedAddress: string) => {
     state.btcDerivedAddress = btcDerivedAddress;
   },
-  [constants.SESSION_SET_BITCOIN_PRICE]: (state, bitcoinPrice) => {
+  [constants.SESSION_SET_BITCOIN_PRICE]: (state, bitcoinPrice: number) => {
     state.bitcoinPrice = bitcoinPrice;
   },
   [constants.SESSION_CLEAR_STATE]: async (state) => {

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -265,3 +265,27 @@ export function convertToRequestBalance(walletAddress: WalletAddress[]) : Reques
 }
 
 export const remove0x = (value: string) => (!value.startsWith('0x') ? value : value.substring(2));
+
+export function getCookie(cname: string) {
+  const name = `${cname}=`;
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(';');
+  let cookieValue = '';
+  ca.forEach((value) => {
+    let c = value;
+    while (c.charAt(0) === ' ') {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) === 0) {
+      cookieValue = c.substring(name.length, c.length);
+    }
+  });
+  return cookieValue;
+}
+
+export function setCookie(cookieName: string, cookieValue: number, expirationHours: number) {
+  const d = new Date();
+  d.setTime(d.getTime() + (expirationHours * 60 * 60 * 1000));
+  const expires = `expires=${d.toUTCString()}`;
+  document.cookie = `${cookieName}=${cookieValue};${expires};path=/`;
+}

--- a/src/common/views/Home.vue
+++ b/src/common/views/Home.vue
@@ -164,6 +164,7 @@ export default {
     const clearSession = useAction('web3Session', constants.SESSION_CLEAR);
     const addPeg = useAction('web3Session', constants.SESSION_ADD_TX_TYPE);
     const setTerms = useAction('web3Session', constants.SESSION_ADD_TERMS_VALUE);
+    const getBtcPrice = useAction('web3Session', constants.SESSION_ADD_BITCOIN_PRICE);
 
     const btcToRbtc = computed((): boolean => txType.value === constants.PEG_IN_TRANSACTION_TYPE);
 
@@ -220,9 +221,10 @@ export default {
       if (route.path !== '/status') router.push('/status');
     }
 
+    clearSession()
+      .then(() => getBtcPrice());
     clear();
     clearPegOut();
-    clearSession();
     addPeg();
 
     return {


### PR DESCRIPTION
		I've added two functions to add and read the btc price on every module.
		The cookie is fetched every time the btc price wants to be consulted, also
		it has a default 12 hours expiration time