### PR TITLE
Send sessionId registering a tx

### DIFF
--- a/src/common/services/ApiService.ts
+++ b/src/common/services/ApiService.ts
@@ -210,13 +210,13 @@ export default class ApiService {
   }
 
   static registerTx({
-    txHash, type, value, wallet, fee,
+    sessionId, txHash, type, value, wallet, fee,
   }: {
-    txHash: string, type: string, value: number, wallet: string, fee: number,
+    sessionId: string, txHash: string, type: string, value: number, wallet: string, fee: number,
   }): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       axios.post(`${ApiService.baseURL}/register`, {
-        txHash, type, value, wallet, fee,
+        sessionId, txHash, type, value, wallet, fee,
       })
         .then(() => resolve())
         .catch(reject);

--- a/src/common/services/ApiService.ts
+++ b/src/common/services/ApiService.ts
@@ -215,6 +215,7 @@ export default class ApiService {
     sessionId: string, txHash: string, type: string, value: number, wallet: string, fee: number,
   }): Promise<void> {
     return new Promise<void>((resolve, reject) => {
+      if (sessionId == null || txHash == null || type == null) resolve();
       axios.post(`${ApiService.baseURL}/register`, {
         sessionId, txHash, type, value, wallet, fee,
       })

--- a/src/pegin/components/ledger/ConfirmLedgerTransaction.vue
+++ b/src/pegin/components/ledger/ConfirmLedgerTransaction.vue
@@ -195,7 +195,7 @@ import * as constants from '@/common/store/constants';
 import { TxStatusType } from '@/common/types/store';
 import { TxSummaryOrientation } from '@/common/types/Status';
 import TxSummaryFixed from '@/common/components/exchange/TxSummaryFixed.vue';
-import { useGetter, useState } from '@/common/store/helper';
+import { useGetter, useState, useStateAttribute } from '@/common/store/helper';
 import AdvancedData from '@/common/components/exchange/AdvancedData.vue';
 import { EnvironmentAccessorService } from '@/common/services/enviroment-accessor.service';
 
@@ -224,6 +224,7 @@ export default defineComponent({
     const refundAddress = useGetter<string>('pegInTx', constants.PEGIN_TX_GET_REFUND_ADDRESS);
     const accountBalanceText = useGetter<string>('pegInTx', constants.PEGIN_TX_GET_ACCOUNT_BALANCE_TEXT);
     const safeFee = useGetter<SatoshiBig>('pegInTx', constants.PEGIN_TX_GET_SAFE_TX_FEE);
+    const sessionId = useStateAttribute<string>('pegInTx', 'sessionId');
 
     const rskFederationAddress = computed(():string => pegInTxState.value.normalizedTx.outputs[1]?.address?.trim() ?? `${environmentContext.getBtcText()} Powpeg address not found`);
 
@@ -274,6 +275,7 @@ export default defineComponent({
         .then((id) => {
           txId.value = id;
           ApiService.registerTx({
+            sessionId: sessionId.value,
             txHash: txId.value,
             type: 'pegin',
             value: Number(pegInTxState.value.amountToTransfer.toBTCTrimmedString()),

--- a/src/pegin/components/liquality/ConfirmLiqualityTransaction.vue
+++ b/src/pegin/components/liquality/ConfirmLiqualityTransaction.vue
@@ -170,7 +170,7 @@ import LiqualityTxBuilder from '@/pegin/middleware/TxBuilder/LiqualityTxBuilder'
 import { TxStatusType } from '@/common/types/store';
 import { TxSummaryOrientation } from '@/common/types/Status';
 import TxSummaryFixed from '@/common/components/exchange/TxSummaryFixed.vue';
-import { useGetter, useState } from '@/common/store/helper';
+import { useGetter, useState, useStateAttribute } from '@/common/store/helper';
 import { EnvironmentAccessorService } from '@/common/services/enviroment-accessor.service';
 
 export default defineComponent({
@@ -200,6 +200,7 @@ export default defineComponent({
     const walletService = useGetter<WalletService>('pegInTx', constants.PEGIN_TX_GET_WALLET_SERVICE);
     const accountBalanceText = useGetter<string>('pegInTx', constants.PEGIN_TX_GET_ACCOUNT_BALANCE_TEXT);
     const safeFee = useGetter<SatoshiBig>('pegInTx', constants.PEGIN_TX_GET_SAFE_TX_FEE);
+    const sessionId = useStateAttribute<string>('pegInTx', 'sessionId');
 
     const feeBTC = computed(():SatoshiBig => safeFee.value);
 
@@ -228,6 +229,7 @@ export default defineComponent({
         .then((txHash) => {
           txId.value = txHash;
           ApiService.registerTx({
+            sessionId: sessionId.value,
             txHash: txId.value,
             type: 'pegin',
             value: Number(pegInTxState.value.amountToTransfer.toBTCTrimmedString()),

--- a/src/pegin/components/trezor/ConfirmTrezorTransaction.vue
+++ b/src/pegin/components/trezor/ConfirmTrezorTransaction.vue
@@ -213,7 +213,7 @@ import * as constants from '@/common/store/constants';
 import { TxStatusType } from '@/common/types/store';
 import { TxSummaryOrientation } from '@/common/types/Status';
 import TxSummaryFixed from '@/common/components/exchange/TxSummaryFixed.vue';
-import { useGetter, useState } from '@/common/store/helper';
+import { useGetter, useState, useStateAttribute } from '@/common/store/helper';
 
 export default defineComponent({
   name: 'ConfirmTrezorTransaction',
@@ -243,6 +243,7 @@ export default defineComponent({
     const refundAddress = useGetter<string>('pegInTx', constants.PEGIN_TX_GET_REFUND_ADDRESS);
     const accountBalanceText = useGetter<string>('pegInTx', constants.PEGIN_TX_GET_ACCOUNT_BALANCE_TEXT);
     const safeFee = useGetter<SatoshiBig>('pegInTx', constants.PEGIN_TX_GET_SAFE_TX_FEE);
+    const sessionId = useStateAttribute<string>('pegInTx', 'sessionId');
 
     async function toTrackId() {
       let txError = '';
@@ -255,6 +256,7 @@ export default defineComponent({
         .then((id) => {
           txId.value = id;
           ApiService.registerTx({
+            sessionId: sessionId.value,
             txHash: txId.value,
             type: 'pegin',
             value: Number(pegInTxState.value.amountToTransfer.toBTCTrimmedString()),

--- a/src/pegout/components/PegOutForm.vue
+++ b/src/pegout/components/PegOutForm.vue
@@ -221,6 +221,7 @@ export default defineComponent({
       sendTx()
         .then(() => {
           ApiService.registerTx({
+            sessionId: '',
             txHash: pegOutTxState.value.txHash as string,
             type: 'pegout',
             value: Number(pegOutTxState.value.amountToTransfer.toRBTCTrimmedString()),


### PR DESCRIPTION
Add session id required to register a transaction using the register endpoint (https://github.com/rsksmart/2wp-api/pull/263).
Send an empty string for pegouts until we modify sessions handling.