### PR TITLE
Access T&C from footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,17 +4,19 @@
     <div class="custom-background">
       <top/>
       <v-row class="d-flex justify-center ma-0">
-        <router-view/>
+        <router-view @update:showDialog="showTermsDialog" />
       </v-row>
-      <footer-rsk/>
+      <terms-dialog v-model:showDialog="showTermsAndConditions" />
+      <footer-rsk @update:showDialog="showTermsDialog" />
     </div>
   </v-app>
 </template>
 <script lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import Top from '@/common/components/layouts/Top.vue';
 import FooterRsk from '@/common/components/layouts/Footer.vue';
 import Mobile from '@/common/views/Mobile.vue';
+import TermsDialog from '@/common/components/common/TermsDialog.vue';
 import { EnvironmentAccessorService } from '@/common/services/enviroment-accessor.service';
 import * as constants from '@/common/store/constants';
 import { useAction } from '@/common/store/helper';
@@ -26,13 +28,14 @@ export default {
     Top,
     FooterRsk,
     Mobile,
+    TermsDialog,
   },
   setup() {
     let scriptTag: HTMLScriptElement;
     let hotjarScriptTag: HTMLScriptElement;
     const getBtcPrice = useAction('web3Session', constants.SESSION_ADD_BITCOIN_PRICE);
     const enableTermsAndConditions = useAction('web3Session', constants.SESSION_ADD_TERMS_AND_CONDITIONS_ENABLED);
-
+    const showTermsAndConditions = ref(false);
     const contentSecurityPolicy = computed((): string => {
       const envVariables = EnvironmentAccessorService.getEnvironmentVariables();
       let response = '';
@@ -83,12 +86,19 @@ export default {
       document.body.appendChild(hotjarScriptTag);
     }
 
+    function showTermsDialog(show: boolean) {
+      showTermsAndConditions.value = show;
+    }
+
     enableTermsAndConditions();
     appendHotjar();
     getBtcPrice();
     appendClarity();
     appendCSP();
-    return {};
+    return {
+      showTermsDialog,
+      showTermsAndConditions,
+    };
   },
 };
 </script>

--- a/src/common/components/common/TermsDialog.vue
+++ b/src/common/components/common/TermsDialog.vue
@@ -1,6 +1,5 @@
-<!-- eslint-disable max-len -->
 <template>
-    <v-dialog v-model:model-value="show" width="650" persistent>
+    <v-dialog v-model="show" width="650" persistent>
       <v-card class="container dialog">
         <v-row class="mx-0 mt-6 d-flex justify-center">
           <v-img :src="require('@/assets/common/terms-conditions.png')" height="60" contain />
@@ -11,12 +10,13 @@
         <v-row>
           <v-container class="terms-txt mx-15 my-6 pa-10" @scroll="onScroll">
             <v-row>
-              <p>{{ $props.text }}</p>
+              <p>{{ dialogText }}</p>
             </v-row>
            </v-container>
         </v-row>
         <v-row class="d-flex justify-end mx-11 my-5">
-          <v-btn rounded variant="outlined" color="#000000" width="110" @click="closeDialog"
+          <v-btn rounded variant="outlined" color="#000000" width="110"
+                 @click="$emit('update:showDialog', false)"
                  :disabled="!scrolledText">
             <span>Back</span>
           </v-btn>
@@ -27,20 +27,27 @@
 
 <script lang="ts">
 import { ref, defineComponent, computed } from 'vue';
+import { useStateAttribute } from '@/common/store/helper';
+import { Feature } from '@/common/types';
 
 export default defineComponent({
   name: 'TermsDialog',
   props: {
     showDialog: Boolean,
-    text: String,
   },
   setup(props, context) {
-    const show = computed(() => props.showDialog);
+    const termsAndConditionsEnabled = useStateAttribute<Feature>('web3Session', 'termsAndConditionsEnabled');
+    const dialogText = computed(() => termsAndConditionsEnabled.value?.value);
+    const show = computed({
+      get() {
+        return props.showDialog;
+      },
+      set(value) {
+        context.emit('update:showDialog', value);
+      },
+    });
     const scrolledText = ref(false);
 
-    function closeDialog() {
-      context.emit('closeDialog', props.showDialog);
-    }
     function onScroll(
       event: { target: { scrollTop: number; clientHeight: number; scrollHeight: number; }},
     ) {
@@ -53,10 +60,10 @@ export default defineComponent({
     }
 
     return {
-      closeDialog,
       show,
       scrolledText,
       onScroll,
+      dialogText,
     };
   },
 });

--- a/src/common/components/common/TermsDialog.vue
+++ b/src/common/components/common/TermsDialog.vue
@@ -8,7 +8,7 @@
           <h2>Terms and conditions</h2>
         </v-row>
         <v-row>
-          <v-container class="terms-txt mx-15 my-6 pa-10" @scroll="onScroll">
+          <v-container class="terms-txt mx-15 my-6 pa-10" @scroll="onScroll" ref="scrollableArea">
             <v-row>
               <p>{{ dialogText }}</p>
             </v-row>
@@ -17,7 +17,7 @@
         <v-row class="d-flex justify-end mx-11 my-5">
           <v-btn rounded variant="outlined" color="#000000" width="110"
                  @click="$emit('update:showDialog', false)"
-                 :disabled="!scrolledText">
+                 :disabled="requiresScroll && !scrolledText ">
             <span>Back</span>
           </v-btn>
         </v-row>
@@ -26,7 +26,9 @@
   </template>
 
 <script lang="ts">
-import { ref, defineComponent, computed } from 'vue';
+import {
+  ref, defineComponent, computed, watchEffect,
+} from 'vue';
 import { useStateAttribute } from '@/common/store/helper';
 import { Feature } from '@/common/types';
 
@@ -36,6 +38,7 @@ export default defineComponent({
     showDialog: Boolean,
   },
   setup(props, context) {
+    const areTermsAccepted = useStateAttribute<boolean>('web3Session', 'acceptedTerms');
     const termsAndConditionsEnabled = useStateAttribute<Feature>('web3Session', 'termsAndConditionsEnabled');
     const dialogText = computed(() => termsAndConditionsEnabled.value?.value);
     const show = computed({
@@ -47,6 +50,8 @@ export default defineComponent({
       },
     });
     const scrolledText = ref(false);
+    const scrollableArea = ref();
+    const requiresScroll = ref();
 
     function onScroll(
       event: { target: { scrollTop: number; clientHeight: number; scrollHeight: number; }},
@@ -59,11 +64,22 @@ export default defineComponent({
       }
     }
 
+    watchEffect(() => {
+      if (scrollableArea.value) {
+        const el = scrollableArea.value.$el;
+        requiresScroll.value = el.scrollHeight > el.clientHeight;
+        scrolledText.value = false;
+      }
+    });
+
     return {
       show,
       scrolledText,
       onScroll,
       dialogText,
+      scrollableArea,
+      requiresScroll,
+      areTermsAccepted,
     };
   },
 });

--- a/src/common/components/common/TermsDialog.vue
+++ b/src/common/components/common/TermsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="show" width="650" persistent>
+    <v-dialog v-model="show" width="650" :persistent="!areTermsAccepted">
       <v-card class="container dialog">
         <v-row class="mx-0 mt-6 d-flex justify-center">
           <v-img :src="require('@/assets/common/terms-conditions.png')" height="60" contain />
@@ -17,7 +17,7 @@
         <v-row class="d-flex justify-end mx-11 my-5">
           <v-btn rounded variant="outlined" color="#000000" width="110"
                  @click="$emit('update:showDialog', false)"
-                 :disabled="requiresScroll && !scrolledText ">
+                 :disabled="requiresScroll && !scrolledText && !areTermsAccepted">
             <span>Back</span>
           </v-btn>
         </v-row>

--- a/src/common/components/layouts/Footer.vue
+++ b/src/common/components/layouts/Footer.vue
@@ -21,7 +21,8 @@
               </a>
               <a :href="helpUrl" target="_blank">Help</a>
               <a :href="discordUrl" target="_blank">Support</a>
-              <a href="https://rootstock.io/terms-conditions/" target="_blank">
+              <a v-if="termsAndConditionsEnabled" href="#"
+                 @click.prevent="$emit('update:showDialog', true)">
                 Terms & Conditions
               </a>
               <a :href="urlApi" target="_blank" rel="noopener">Api Version: {{apiVersion}}</a>
@@ -57,8 +58,9 @@ import { mdiTwitter, mdiGithub, mdiDiscord } from '@mdi/js';
 import { ApiInformation } from '@/common/types/ApiInformation';
 import { ApiService } from '@/common/services';
 import { useRoute } from 'vue-router';
-import { useGetter } from '@/common/store/helper';
+import { useGetter, useStateAttribute } from '@/common/store/helper';
 import * as constants from '@/common/store/constants';
+import { Feature } from '@/common/types';
 
 export default {
   name: 'FooterRsk',
@@ -71,6 +73,7 @@ export default {
     const isTrezor = useGetter<boolean>('web3Session', constants.SESSION_IS_TREZOR_CONNECTED);
     const isMetamask = useGetter<boolean>('web3Session', constants.SESSION_IS_METAMASK_CONNECTED);
     const isRloginDefined = useGetter<boolean>('web3Session', constants.SESSION_IS_RLOGIN_DEFINED);
+    const termsAndConditionsEnabled = useStateAttribute<Feature>('web3Session', 'termsAndConditionsEnabled');
 
     const urlApp = computed(() => `https://github.com/rsksmart/2wp-app/releases/tag/v${appVersion.value}`);
     const urlApi = computed(() => `https://github.com/rsksmart/2wp-api/releases/tag/v${apiVersion.value}`);
@@ -116,6 +119,7 @@ export default {
       mdiTwitter,
       mdiDiscord,
       mdiGithub,
+      termsAndConditionsEnabled,
     };
   },
 };

--- a/src/common/views/Home.vue
+++ b/src/common/views/Home.vue
@@ -25,8 +25,9 @@
                             @click="updateCookie" >
                     </label>
                     I acknowledge and accept the
-                    <a href="#" rel="noopener" @key-press="toggleCheck"
-                    class="px-1" @click="showDialog"> terms and conditions</a>
+                    <a href="#" rel="noopener" @key-press="toggleCheck" class="px-1"
+                       @click.prevent="$emit('update:showDialog', true)">
+                    terms and conditions</a>
                   </v-row>
               </v-row>
             </v-col>
@@ -128,8 +129,6 @@
             </v-row>
         </v-col>
       </v-row>
-    <terms-dialog :show-dialog="showTermsAndConditions"
-    @closeDialog="closeTermsDialog" :text="dialogText"/>
     </v-container>
   </v-container>
 </template>
@@ -146,13 +145,9 @@ import {
   TransactionType,
 } from '@/common/types';
 import { useAction, useStateAttribute } from '@/common/store/helper';
-import TermsDialog from '@/common/components/common/TermsDialog.vue';
 
 export default {
   name: 'HomeView',
-  components: {
-    TermsDialog,
-  },
   setup() {
     const router = useRouter();
     const STATUS = ref(false);
@@ -169,8 +164,6 @@ export default {
     const clearSession = useAction('web3Session', constants.SESSION_CLEAR);
     const addPeg = useAction('web3Session', constants.SESSION_ADD_TX_TYPE);
     const setTerms = useAction('web3Session', constants.SESSION_ADD_TERMS_VALUE);
-
-    const dialogText = computed(() => termsAndConditionsEnabled.value?.value ?? '');
 
     const btcToRbtc = computed((): boolean => txType.value === constants.PEG_IN_TRANSACTION_TYPE);
 
@@ -249,7 +242,6 @@ export default {
       closeTermsDialog,
       areTermsAccepted,
       termsAndConditionsEnabled,
-      dialogText,
       showDialog,
       toggleCheck,
       updateCookie,


### PR DESCRIPTION
If Terms and Conditions are enabled
- Open the modal from the footer link
- Enable the back button if the text is not large enough to scroll
- Enable closing modal if terms are accepted by pressing esc or clicking outside the modal