### PR TITLE
Avoid negative amount to receive on pegout

### DIFF
--- a/src/common/styles/_exchange-form.scss
+++ b/src/common/styles/_exchange-form.scss
@@ -250,6 +250,17 @@
   .btn-max:hover {
     cursor: pointer;
   }
+
+  .alert-msg {
+    border-radius: 8px;
+    border: solid #DF1B42;
+    .title {
+      font-weight: bold;
+      font-size: 18px;
+      line-height: 17px;
+      color: #DF1B42;
+    }
+  }
 }
 
 .tooltip-form {


### PR DESCRIPTION
		I've updated the PegoutForm in order to chack the amount to receive
		and do an explicit warning if the total fee to pay causes the received amount
		to be zero or a negative value