### PR TITLE
fixing checksum for non RSK address on pegin page

### DIFF
--- a/src/pegin/components/create/RskAddressInput.vue
+++ b/src/pegin/components/create/RskAddressInput.vue
@@ -145,13 +145,12 @@ export default defineComponent({
     }
 
     function checkStep() {
-      let state;
+      let state = 'valid';
       if (!isValidPegInAddress.value) {
         setRskAddress('');
         state = 'invalid';
       } else {
         setRskAddress(computedRskAddress.value);
-        state = isValidRskAddress.value ? 'valid' : 'warning';
       }
       context.emit('state', state);
     }


### PR DESCRIPTION
- fix the problem in the pegin page when the user is using a different checksum address