### PR TITLE
Fix signing inputs collection on xverse

### DIFF
--- a/src/common/services/XverseService.ts
+++ b/src/common/services/XverseService.ts
@@ -57,8 +57,12 @@ export default class XverseService extends WalletService {
         const xverseTx = tx as XverseTx;
         return new Promise<SignedTx>((resolve, reject) => {
           const signInputs: Record<string, number[]> = {};
-          xverseTx.inputs.forEach((input: { address: string | number; idx: number; }) => {
-            signInputs[input.address] = [input.idx];
+          xverseTx.inputs.forEach((input: { address: string; idx: number; }, inputIdx) => {
+            if (signInputs[input.address]) {
+              signInputs[input.address].push(inputIdx);
+            } else {
+              signInputs[input.address] = [inputIdx];
+            }
           });
           const signPsbtOptions = {
             psbt: xverseTx.base64UnsignedPsbt,

--- a/src/pegin/middleware/TxBuilder/XverseTxBuilder.ts
+++ b/src/pegin/middleware/TxBuilder/XverseTxBuilder.ts
@@ -15,7 +15,6 @@ export interface XverseTx extends Tx {
 
 export default class XverseTxBuilder extends TxBuilder {
   buildTx(normalizedTx: NormalizedTx): Promise<XverseTx> {
-    console.log('XverseTxBuilder.buildTx()');
     return new Promise<XverseTx>((resolve, reject) => {
       const psbt = new bitcoin.Psbt({ network: this.network });
       this.getExtendedInputs(normalizedTx.inputs)


### PR DESCRIPTION
		I've updated the signingInput collection on the xverse service in order to select
		the inputs indexes of the created tx instead of the utxo.
		Reported by <lucio.serra@iovlabs.org>