### PR TITLE
Add features to cookie storage

### DIFF
--- a/src/common/store/constants.ts
+++ b/src/common/store/constants.ts
@@ -315,6 +315,7 @@ export const MAINNET_ADDRESS_NSEGWIT = '^[bc1][0-9A-HJ-NP-Za-z]{41,62}';
 export const POWPEG_RSKT_HEADER = '52534b5401';
 export const PEGIN_OUTPUTS = 3;
 export const COOKIE_EXPIRATION_HOURS = 12;
+export const FEATURES_COOKIE_EXPIRATION_HOURS = 48;
 
 export const POWPEG = 'powpeg';
 export const FLYOVER = 'flyover';


### PR DESCRIPTION
		I set the features data to be stored in a 48 hours cookie in order to reduce the
		api calls