### PR TITLE
fix: remove cached provider from rLogin

### DIFF
--- a/src/common/utils/rlogin.ts
+++ b/src/common/utils/rlogin.ts
@@ -35,7 +35,7 @@ export function getRloginInstance(): RLogin {
   }
   const supportedChains = Object.keys(rpcUrls).map(Number);
   const rLoginSetup = new RLogin({
-    cacheProvider: true,
+    cacheProvider: false,
     defaultTheme: 'dark',
     providerOptions: {
       walletconnect: {


### PR DESCRIPTION
[TWPAPP-897](https://rsklabs.atlassian.net/jira/software/projects/TWPAPP/boards/128?selectedIssue=TWPAPP-897)

Trezor connection for rsk address, fixed issue of not being able to connect when reloading the page for the cached provider of rLogin.