### PR TITLE
Add Wei to Satoshi safe conversion

### DIFF
--- a/src/common/services/FlyoverService.ts
+++ b/src/common/services/FlyoverService.ts
@@ -338,11 +338,11 @@ export default class FlyoverService {
               quote: {
                 ...quote,
                 timeForDepositInSeconds: quote.timeForDeposit,
-                callFee: new SatoshiBig(new WeiBig(quote.callFee ?? 0, 'wei').toRBTCString(), 'btc'),
+                callFee: SatoshiBig.fromWeiBig(new WeiBig(quote.callFee ?? 0, 'wei')),
                 gasFee: new WeiBig(quote.gasFee ?? 0, 'wei'),
                 penaltyFee: new WeiBig(quote.penaltyFee ?? 0, 'wei'),
-                productFeeAmount: new SatoshiBig(new WeiBig(quote.productFeeAmount ?? 0, 'wei').toRBTCString(), 'btc'),
-                value: new SatoshiBig(new WeiBig(quote.value ?? 0, 'wei').toRBTCString(), 'btc'),
+                productFeeAmount: SatoshiBig.fromWeiBig(new WeiBig(quote.productFeeAmount ?? 0, 'wei')),
+                value: SatoshiBig.fromWeiBig(new WeiBig(quote.value ?? 0, 'wei')),
               },
               quoteHash,
             }));

--- a/src/common/types/SatoshiBig.ts
+++ b/src/common/types/SatoshiBig.ts
@@ -1,4 +1,5 @@
 import Big, { BigSource } from 'big.js';
+import WeiBig from './WeiBig';
 
 const numberRegex = /^[0-9]*(\.[0-9]*)?$/;
 
@@ -25,6 +26,11 @@ export default class SatoshiBig extends Big {
         super(safeBig);
         break;
     }
+  }
+
+  public static fromWeiBig(weiBig: WeiBig): SatoshiBig {
+    const safeSatBig = new Big(weiBig.toRBTCString());
+    return new SatoshiBig(safeSatBig.mul(100_000_000).toFixed(0, Big.roundUp), 'satoshi');
   }
 
   plus(amount: SatoshiBig) {

--- a/src/pegin/components/create/PegInForm.vue
+++ b/src/pegin/components/create/PegInForm.vue
@@ -223,7 +223,7 @@ export default defineComponent({
               amountToTransferInSatoshi: selectedQuote.value?.quote.value
                 .plus(selectedQuote.value?.quote.productFeeAmount)
                 .plus(selectedQuote.value?.quote.callFee)
-                .plus(new SatoshiBig(selectedQuote.value?.quote.gasFee.toRBTCString(), 'btc')),
+                .plus(SatoshiBig.fromWeiBig(selectedQuote.value?.quote.gasFee)),
               refundAddress: '',
               recipient: '',
               feeLevel: pegInTxState.value.selectedFee,

--- a/tests/unit/SatoshiBig.spec.ts
+++ b/tests/unit/SatoshiBig.spec.ts
@@ -1,5 +1,6 @@
 import Big from 'big.js';
 import SatoshiBig from '@/common/types/SatoshiBig';
+import { WeiBig } from '@/common/types';
 
 describe('SatoshiBig', () => {
   it('should be a valid instance passing string, integer and big values', () => {
@@ -56,5 +57,32 @@ describe('SatoshiBig', () => {
     const sb1: SatoshiBig = new SatoshiBig(0, 'satoshi');
     expect(sb1.toBTCString()).toEqual('0.00000000');
     expect(sb1.toBTCStringNotZeroPadded()).toEqual('0');
+  });
+  
+  it('should return an instance of SatoshiBig from a WeiBig instance rounded up', () => {
+    const weiToTest = new WeiBig('5301364444000000', 'wei');
+    const weiToTest2 = new WeiBig('8101341211956000', 'wei');
+    const weiToTest3 = new WeiBig('9101347211956000', 'wei');
+    const weiToTest4 = new WeiBig('5301360444000000', 'wei');
+    const weiToTest5 = new WeiBig('530136', 'wei');
+    const weiToTest6 = new WeiBig('5301360000000001', 'wei');
+    const sb1:SatoshiBig = SatoshiBig.fromWeiBig(weiToTest);
+    const sb2:SatoshiBig = SatoshiBig.fromWeiBig(weiToTest2);
+    const sb3:SatoshiBig = SatoshiBig.fromWeiBig(weiToTest3);
+    const sb4:SatoshiBig = SatoshiBig.fromWeiBig(weiToTest4);
+    const sb5:SatoshiBig = SatoshiBig.fromWeiBig(weiToTest5);
+    const sb6:SatoshiBig = SatoshiBig.fromWeiBig(weiToTest6);
+    expect(sb1).toBeInstanceOf(SatoshiBig);
+    expect(sb1.toSatoshiString()).toEqual('530137');
+    expect(sb2).toBeInstanceOf(SatoshiBig);
+    expect(sb2.toSatoshiString()).toEqual('810135');
+    expect(sb3).toBeInstanceOf(SatoshiBig);
+    expect(sb3.toSatoshiString()).toEqual('910135');
+    expect(sb4).toBeInstanceOf(SatoshiBig);
+    expect(sb4.toSatoshiString()).toEqual('530137');
+    expect(sb5).toBeInstanceOf(SatoshiBig);
+    expect(sb5.toSatoshiString()).toEqual('1');
+    expect(sb6).toBeInstanceOf(SatoshiBig);
+    expect(sb6.toSatoshiString()).toEqual('530137');
   });
 });


### PR DESCRIPTION
		We've added a new method on the satoshiBig class in order to
		convert wei into satoshi amounts making a round up given the precision issue.