### PR TITLE
build(deps): bump webpack from 5.88.2 to 5.95.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8168,9 +8168,15 @@
       }
     },
     "node_modules/@types/estree": {
+<<<<<<< HEAD
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+=======
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+>>>>>>> 22dd8db (build(deps): bump webpack from 5.88.2 to 5.95.0)
       "devOptional": true
     },
     "node_modules/@types/express": {
@@ -28298,9 +28304,15 @@
       }
     },
     "node_modules/terser": {
+<<<<<<< HEAD
       "version": "5.31.6",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
       "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
+=======
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.34.0.tgz",
+      "integrity": "sha512-y5NUX+U9HhVsK/zihZwoq4r9dICLyV2jXGOriDAVOeKhq3LKVjgJbGO90FisozXLlJfvjHqgckGmJFBb9KYoWQ==",
+>>>>>>> 22dd8db (build(deps): bump webpack from 5.88.2 to 5.95.0)
       "devOptional": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -31539,9 +31551,15 @@
       }
     },
     "node_modules/webpack": {
+<<<<<<< HEAD
       "version": "5.94.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+=======
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+>>>>>>> 22dd8db (build(deps): bump webpack from 5.88.2 to 5.95.0)
       "devOptional": true,
       "dependencies": {
         "@types/estree": "^1.0.5",


### PR DESCRIPTION
[TWPAPP-948](https://rsklabs.atlassian.net/jira/software/projects/TWPAPP/boards/128?selectedIssue=TWPAPP-948)

Bumps [webpack](https://github.com/webpack/webpack) from 5.88.2 to 5.95.0.
- [Release notes](https://github.com/webpack/webpack/releases)
- [Commits](https://github.com/webpack/webpack/compare/v5.88.2...v5.95.0)

---
updated-dependencies:
- dependency-name: webpack dependency-type: indirect ...