### PR TITLE
fix: flyover 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "@mdi/font": "^7.2.96",
         "@mdi/js": "^6.9.96",
         "@rsksmart/bridges-core-sdk": "^0.3.3",
-        "@rsksmart/flyover-sdk": "^1.5.1",
-        "@rsksmart/rlogin": "^1.6.1",
+        "@rsksmart/flyover-sdk": "^1.5.2",
+        "@rsksmart/rlogin": "^1.5.3-beta.1",
         "@rsksmart/rlogin-ledger-provider": "^1.0.3",
         "@rsksmart/rlogin-trezor-provider": "^1.0.3",
         "@rsksmart/rsk-precompiled-abis": "^6.0.0-ARROWHEAD",
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/@rsksmart/flyover-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/flyover-sdk/-/flyover-sdk-1.5.1.tgz",
-      "integrity": "sha512-WbWesV+3SoCIgruDq8GY9IPx5Rrm9gNJI6VDSTmQYHYzJ6xd3ZC1gu1c2LJjowtlRxyAGMAOvq34AasKsnL4AQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/flyover-sdk/-/flyover-sdk-1.5.2.tgz",
+      "integrity": "sha512-0tIO8fYFkk8JgO2G6f2JShX0qRJJ2VigvBuZL51VtRvHRmQWScW15y48lZskQ+MGXxGqXvA5mn0RD568yNAK+w==",
       "dependencies": {
         "@rsksmart/bridges-core-sdk": "^0.3.3",
         "qrcode": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mdi/font": "^7.2.96",
     "@mdi/js": "^6.9.96",
     "@rsksmart/bridges-core-sdk": "^0.3.3",
-    "@rsksmart/flyover-sdk": "^1.5.1",
+    "@rsksmart/flyover-sdk": "^1.5.2",
     "@rsksmart/rlogin": "^1.5.3-beta.1",
     "@rsksmart/rlogin-ledger-provider": "^1.0.3",
     "@rsksmart/rlogin-trezor-provider": "^1.0.3",


### PR DESCRIPTION
Update flyover version to avoid `getProviders()` error response