### PR TITLE
Fix pegin destination address usage

### DIFF
--- a/src/pegin/components/create/ConfirmationSteps.vue
+++ b/src/pegin/components/create/ConfirmationSteps.vue
@@ -286,7 +286,7 @@
                 <v-textarea hide-details auto-grow readonly
                             class="text-bw-400"
                             variant="outlined" density="compact" rows="1"
-                            :model-value="rskFederationAddress" />
+                            :model-value="providerRecipientAddress" />
               </v-row>
               <div v-if="existChange" >
                 <v-row no-gutters class="mb-2 mt-4">

--- a/src/pegin/components/create/PegInForm.vue
+++ b/src/pegin/components/create/PegInForm.vue
@@ -116,7 +116,7 @@ export default defineComponent({
     const environmentContext = EnvironmentContextProviderService.getEnvironmentContext();
     const flyoverEnabled = ref(true);
     const loadingQuotes = ref(false);
-    const selected = ref<constants.peginType>();
+    const selected = ref<constants.peginType | null>(null);
     const selectedQuote = ref<PeginQuote>();
     const showErrorDialog = ref(false);
     const txError = ref<ServiceError>(new ServiceError('', '', '', ''));
@@ -202,7 +202,10 @@ export default defineComponent({
       pegInFormState.value.send('fill');
     }
 
-    async function changeSelectedOption(selectedType: constants.peginType, quote?: PeginQuote) {
+    async function changeSelectedOption(
+      selectedType: constants.peginType | null,
+      quote?: PeginQuote,
+    ) {
       selected.value = selectedType;
       await setPeginType(selected.value);
       selectedQuote.value = quote;
@@ -212,7 +215,7 @@ export default defineComponent({
     async function getQuotes() {
       loadingQuotes.value = true;
       getPeginQuotes({
-        rootstockRecipientAddress: account.value,
+        rootstockRecipientAddress: flyoverPeginState.value.rootstockRecipientAddress,
         bitcoinRefundAddress: refundAddress.value,
       })
         .finally(() => {
@@ -228,17 +231,17 @@ export default defineComponent({
     const showOptions = computed(() => !loadingQuotes.value
     && !loadingFee.value && validAddress.value && validAmount.value);
 
-    function checkValidAddress(isValid: boolean, amountInformed: string) {
+    function checkValidAddress(isValid: boolean, addressInformed: string) {
       validAddress.value = isValid;
-      if (isValid && amountInformed !== amount.value) {
-        amount.value = amountInformed;
+      if (isValid && addressInformed !== address.value) {
+        address.value = addressInformed;
       }
     }
 
-    function checkValidAmount(isValid: boolean, addressInformed: string) {
+    function checkValidAmount(isValid: boolean, amountInformed: string) {
       validAmount.value = isValid;
-      if (isValid && addressInformed !== address.value) {
-        address.value = addressInformed;
+      if (isValid && amountInformed !== amount.value) {
+        amount.value = amountInformed;
       }
     }
 
@@ -246,6 +249,7 @@ export default defineComponent({
       if (!validAmount.value || !validAddress.value) {
         return;
       }
+      await changeSelectedOption(null);
       await getQuotes();
     });
 


### PR DESCRIPTION
Watch address changes, ensure the most recent quote is selected and get address from flyover peg-in store.
Also, fix the incorrect provider address displayed in the confirmation steps for flyover peg-ins when using software wallets.