### PR TITLE
fix: show pegout options only with valid amount

### DIFF
--- a/src/pegout/components/PegoutForm.vue
+++ b/src/pegout/components/PegoutForm.vue
@@ -479,8 +479,7 @@ export default defineComponent({
       getQuotes();
     });
 
-    const showStep = computed(() => (!loadingQuotes.value && validAmount.value)
-      || !props.flyoverEnabled);
+    const showStep = computed(() => (!loadingQuotes.value && validAmount.value));
 
     function changeSelectedOption(quoteHash: string) {
       setSelectedQuoteHash(quoteHash);


### PR DESCRIPTION
[TWPAPP-1029](https://rsklabs.atlassian.net/jira/software/projects/TWPAPP/boards/128?selectedIssue=TWPAPP-1029)

<img width="1199" alt="Screenshot 2024-12-09 at 4 27 55 PM" src="https://github.com/user-attachments/assets/c3d077f2-e505-4c28-918a-45739fb84efd">
<img width="1204" alt="Screenshot 2024-12-09 at 4 28 02 PM" src="https://github.com/user-attachments/assets/00c7f2c1-fb37-4024-8439-d6b4a4c04cca">
